### PR TITLE
fix: correct import path for autoplay module

### DIFF
--- a/build/structures/Player.js
+++ b/build/structures/Player.js
@@ -3,7 +3,7 @@ const { ActivityType } = require('discord.js');
 const { Connection } = require("./Connection");
 const { Filters } = require("./Filters");
 const { Queue } = require("./Queue");
-const { spAutoPlay, scAutoPlay } = require('../handlers/autoplay');
+const { spAutoPlay, scAutoPlay } = require('../handlers/autoPlay');
 const { inspect } = require("util");
 
 class Player extends EventEmitter {


### PR DESCRIPTION
Changed require('../handlers/autoplay') to require('../handlers/autoPlay'), which was causing a "Cannot find module" error on case-sensitive filesystems (Linux)